### PR TITLE
fixed FactoryInterface example

### DIFF
--- a/proposed/container-meta.md
+++ b/proposed/container-meta.md
@@ -162,6 +162,8 @@ interface FactoryInterface
 
 class ExampleFactory implements FactoryInterface
 {
+    protected $container;
+    
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
@@ -169,7 +171,7 @@ class ExampleFactory implements FactoryInterface
 
     public function newInstance()
     {
-        return new Example($container->get('db'));
+        return new Example($this->container->get('db'));
     }
 }
 ```


### PR DESCRIPTION
Missing property `ExampleFactory::$container`
And fixed bug in `ExampleFactory::newInstance()`
